### PR TITLE
allow user to provide path to real certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ cd kolide-demo
 ./demo.sh up
 ```
 
-On the first run, a self-signed SSL certificate will be generated to be used with your trial instance of Kolide. Please enter a CN for this certificate that osquery hosts will be able to use to connect.
+On the first run, a self-signed TLS certificate will be generated to be used with your trial instance of Kolide. Please enter a CN for this certificate that osquery hosts will be able to use to connect.
+If you already have a trusted TLS certificate, you can provide it in this step.
+```
+./demo.sh /path/to/server.key /path/to/server.crt
+```
 
 When startup completes successfully, a message will be printed with a link to the Kolide instance. At this URL you will be walked through licensing and final setup.
 
@@ -36,7 +40,7 @@ This will terminate the containers running Kolide and its dependencies, but data
 ./demo.sh reset
 ```
 
-This will terminate the containers, and remove the MySQL data and generated SSL certificate. Use `./demo.sh up` to start again from scratch.
+This will terminate the containers, and remove the MySQL data and generated TLS certificate. Use `./demo.sh up` to start again from scratch.
 
 ## Testing with Email (Optional)
 

--- a/demo.sh
+++ b/demo.sh
@@ -65,7 +65,7 @@ function reset() {
 function usage() {
     echo "usage: ./demo.sh <subcommand>\n"
     echo "subcommands:"
-    echo "    up <path to TLS key> <path to TLS certificate>"
+    echo "    up [path to TLS key] [path to TLS certificate]"
     echo "    up    Bring up the demo Kolide instance and dependencies"
     echo "    up    up will generate a self signed certificate by default"
     echo "    down  Shut down the demo Kolide instance and dependencies"


### PR DESCRIPTION
Adds optional config to the `up` command. 
```
up /path/to/server.key /path/to/server.crt
```

If the user specifies a key and a cert, these will be copied into the folder and used during setup. 