### PR TITLE
add support for building rpm and debs with osqueryd configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,9 @@
 server.crt
 server.key
 out/
-enrollment/mac/root/etc/osquery
 docker_hosts
 osquery_status
 osquery_result
+enrollment/mac/root/etc/osquery
+enrollment/linux/pkgroot/etc/osquery
 mysqldata/


### PR DESCRIPTION
Builds 
```
out
├── enroll-kolide-1.0.0-1.x86_64.rpm
└── enroll-kolide_1.0.0_amd64.deb
```

WIP still need to do a few things
* add systemd unit
* test that packages work
* update documentation