### PR TITLE
send SIGTERM to osqueryd before unloading

### DIFF
--- a/enrollment/mac/scripts/postinstall
+++ b/enrollment/mac/scripts/postinstall
@@ -2,6 +2,8 @@
 
 [[ $3 != "/" ]] && exit 0
 
+/bin/launchctl stop co.kolide.osquery.enroll
+sleep 5
 /bin/launchctl unload /Library/LaunchDaemons/co.kolide.osquery.enroll.plist
 /bin/launchctl load /Library/LaunchDaemons/co.kolide.osquery.enroll.plist
 


### PR DESCRIPTION
this PR sends a `SIGTERM` and waits 5 seconds before unloading the osqueryd launchd. 
It makes the package install take 5 seconds later but will avoid corrupting rocksdb. 

(in production I'd recommend users reboot when reloading daemons)