### PR TITLE
use /usr/bin/env bash instead of /bin/sh

### DIFF
--- a/demo.sh
+++ b/demo.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 function print_etc_hosts_instructions() {
     CN=$1


### PR DESCRIPTION
on macOS /bin/sh is aliased to /bin/bash, but each OS is a bit different

