### PR TITLE
create the mysqldata folder before starting the container

### DIFF
--- a/demo.sh
+++ b/demo.sh
@@ -17,6 +17,11 @@ function compose_network() {
     echo $(compose_basename)_default
 }
 
+function initialize_data() {
+    mkdir -p mysqldata
+    chmod -R 777 mysqldata/
+}
+
 function mac_enrollment_package() {
     PKGNAME=kolide-enroll
     PKGVERSION=1.0.0
@@ -191,6 +196,8 @@ function wait_mysql() {
 }
 
 function up() {
+    initialize_data
+
     if [ "$1" != "simple" ]; then
         # copy user provided key and cert.
         key=$1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       MYSQL_USER: kolide
       MYSQL_PASSWORD: kolide
     volumes:
-      - .:/tmp
+      - ./mysqldata:/tmp
     expose:
       - "3306"
 


### PR DESCRIPTION
Many users clone the repo and run the script on linux as root,
causing permission issues in the mysql container. We pre-create the mysqldata folder
and chmod it to prevent issues.

Closes #25